### PR TITLE
feat: 検索バーのAgent iボタン非表示設定を追加

### DIFF
--- a/app/src/main/java/app/zipper/knot/KnotConfig.java
+++ b/app/src/main/java/app/zipper/knot/KnotConfig.java
@@ -122,6 +122,12 @@ public class KnotConfig {
       ModuleStrings.OPT_REMOVE_AI_FRIENDS_BUTTON_LABEL,
       ModuleStrings.OPT_REMOVE_AI_FRIENDS_BUTTON_DESC, false, Category.DISPLAY);
 
+  public Item removeSearchBarAgentIButton = new Item(
+      "remove_search_bar_agent_i_button",
+      ModuleStrings.OPT_REMOVE_SEARCH_BAR_AGENT_I_BUTTON_LABEL,
+      ModuleStrings.OPT_REMOVE_SEARCH_BAR_AGENT_I_BUTTON_DESC, false,
+      Category.DISPLAY);
+
   public Item removeOpenChatButton = new Item(
       "remove_open_chat_button",
       ModuleStrings.OPT_REMOVE_OPEN_CHAT_BUTTON_LABEL,
@@ -141,6 +147,7 @@ public class KnotConfig {
       ModuleStrings.OPT_CUSTOM_FONT_PATH_DESC, false, Category.DISPLAY);
 
   public Item[] items = {removeAiFriendsButton,
+                         removeSearchBarAgentIButton,
                          removeOpenChatButton,
                          removeAds,
                          removeTabVoom,

--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -27,6 +27,7 @@ public class LineVersion {
     public StickerTrial stickerTrial = new StickerTrial();
     public Notification notification = new Notification();
     public TalkTabHeader talkTabHeader = new TalkTabHeader();
+    public SearchBarAgentI searchBarAgentI = new SearchBarAgentI();
     public AiIcon aiIcon = new AiIcon();
 
     public static class Main {
@@ -298,6 +299,20 @@ public class LineVersion {
       public String buttonListStateField = "";
       public String iconTypeClass = "";
       public String iconTypeFieldInButton = "";
+    }
+
+    public static class SearchBarAgentI {
+      public String talkVisibleMethod = "";
+      public String talkClickMethod = "";
+      public String homeSearchBarClass = "";
+      public String homeRefreshMethod = "";
+      public String homeRootViewField = "";
+      public String homeTabTypeField = "";
+      public String homeTabName = "";
+      public String homeTabV2Name = "";
+      public int homeAiContainerId = 0;
+      public int homeGuidelineId = 0;
+      public int homeGuidelineEndDp = 0;
     }
 
     public static class AiIcon {

--- a/app/src/main/java/app/zipper/knot/hooks/RemoveHeaderButtons.java
+++ b/app/src/main/java/app/zipper/knot/hooks/RemoveHeaderButtons.java
@@ -1,5 +1,8 @@
 package app.zipper.knot.hooks;
 
+import android.content.Context;
+import android.view.View;
+import androidx.constraintlayout.widget.Guideline;
 import app.zipper.knot.KnotConfig;
 import app.zipper.knot.LineVersion;
 import app.zipper.knot.Main;
@@ -7,6 +10,7 @@ import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,8 +20,13 @@ public class RemoveHeaderButtons implements BaseHook {
   public void hook(KnotConfig config, XC_LoadPackage.LoadPackageParam lpparam)
       throws Throwable {
     if (!config.removeAiFriendsButton.enabled &&
+        !config.removeSearchBarAgentIButton.enabled &&
         !config.removeOpenChatButton.enabled)
       return;
+
+    if (config.removeSearchBarAgentIButton.enabled) {
+      hookHomeSearchBarAiButton(lpparam.classLoader);
+    }
 
     LineVersion.Config cfg = LineVersion.get();
     if (cfg == null || cfg.talkTabHeader.chatTabHeaderStateClass.isEmpty())
@@ -28,9 +37,14 @@ public class RemoveHeaderButtons implements BaseHook {
     Class<?> iconTypeCls = XposedHelpers.findClass(
         cfg.talkTabHeader.iconTypeClass, lpparam.classLoader);
 
-    Object aiFriend = safeValueOf(iconTypeCls, "AI_FRIEND");
+    final Object aiFriend =
+        firstAvailableValueOf(iconTypeCls, "AI_FRIEND", "AI_FRIENDS");
     Object album = safeValueOf(iconTypeCls, "ALBUM");
     Object openChat = safeValueOf(iconTypeCls, "OPEN_CHAT");
+
+    if (config.removeSearchBarAgentIButton.enabled) {
+      hookSearchBarAiButton(cls);
+    }
 
     XposedBridge.hookAllConstructors(cls, new XC_MethodHook() {
       @Override
@@ -125,5 +139,142 @@ public class RemoveHeaderButtons implements BaseHook {
     } catch (Exception e) {
       return null;
     }
+  }
+
+  private static Object firstAvailableValueOf(Class<?> cls,
+                                              String... names) {
+    for (String name : names) {
+      Object value = safeValueOf(cls, name);
+      if (value != null)
+        return value;
+    }
+    return null;
+  }
+
+  private static void hookSearchBarAiButton(Class<?> cls) {
+    Method searchBarAiVisible = null;
+    Method searchBarAiClick = null;
+
+    for (Method method : cls.getDeclaredMethods()) {
+      if (method.getParameterCount() != 0)
+        continue;
+      if (method.getName().equals("w") &&
+          method.getReturnType() == boolean.class) {
+        searchBarAiVisible = method;
+      } else if (method.getName().equals("r") &&
+                 method.getReturnType() == void.class) {
+        searchBarAiClick = method;
+      }
+    }
+
+    if (searchBarAiVisible != null) {
+      XposedBridge.hookMethod(searchBarAiVisible, new XC_MethodHook() {
+        @Override
+        protected void beforeHookedMethod(MethodHookParam param)
+            throws Throwable {
+          if (Main.options.removeSearchBarAgentIButton.enabled)
+            param.setResult(false);
+        }
+      });
+    } else {
+      XposedBridge.log(
+          "Knot: RemoveHeaderButtons could not find search bar AI "
+          + "visibility method.");
+    }
+
+    if (searchBarAiClick != null) {
+      XposedBridge.hookMethod(searchBarAiClick, new XC_MethodHook() {
+        @Override
+        protected void beforeHookedMethod(MethodHookParam param)
+            throws Throwable {
+          if (Main.options.removeSearchBarAgentIButton.enabled)
+            param.setResult(null);
+        }
+      });
+    }
+
+    if (searchBarAiVisible != null || searchBarAiClick != null) {
+      XposedBridge.log(
+          "Knot: RemoveHeaderButtons hooked Talk search bar Agent i button.");
+    }
+  }
+
+  private static void hookHomeSearchBarAiButton(ClassLoader classLoader) {
+    Class<?> cls;
+    try {
+      cls = XposedHelpers.findClass("ni4.h", classLoader);
+    } catch (Throwable t) {
+      XposedBridge.log(
+          "Knot: RemoveHeaderButtons could not find Home search bar class.");
+      return;
+    }
+
+    XC_MethodHook patchHook = new XC_MethodHook() {
+      @Override
+      protected void afterHookedMethod(MethodHookParam param)
+          throws Throwable {
+        if (!Main.options.removeSearchBarAgentIButton.enabled)
+          return;
+        try {
+          patchHomeSearchBarAiButton(param.thisObject);
+        } catch (Exception e) {
+          XposedBridge.log(
+              "Knot: RemoveHeaderButtons Home search bar error: " + e);
+        }
+      }
+    };
+
+    XposedBridge.hookAllConstructors(cls, patchHook);
+    XposedBridge.hookAllMethods(cls, "e", patchHook);
+    XposedBridge.log(
+        "Knot: RemoveHeaderButtons hooked Home search bar Agent i button.");
+  }
+
+  private static void patchHomeSearchBarAiButton(Object instance) {
+    if (!isHomeSearchBar(instance))
+      return;
+
+    View rootView = (View)XposedHelpers.getObjectField(instance, "c");
+    if (rootView == null)
+      return;
+
+    Context context = rootView.getContext();
+    int aiContainerId = getTargetResourceId(
+        context, "main_tab_ai_entry_icon_container", "id");
+    if (aiContainerId == 0)
+      return;
+
+    View aiContainer = rootView.findViewById(aiContainerId);
+    if (aiContainer == null)
+      return;
+
+    aiContainer.setOnClickListener(null);
+    aiContainer.setClickable(false);
+    aiContainer.setVisibility(View.GONE);
+
+    int guidelineId = getTargetResourceId(context, "main_tab_guideline", "id");
+    View guidelineView =
+        guidelineId != 0 ? rootView.findViewById(guidelineId) : null;
+    if (guidelineView instanceof Guideline)
+      ((Guideline)guidelineView).setGuidelineEnd(dpToPx(context, 55f));
+  }
+
+  private static boolean isHomeSearchBar(Object instance) {
+    Object tabType = XposedHelpers.getObjectField(instance, "b");
+    if (!(tabType instanceof Enum<?>))
+      return false;
+    String name = ((Enum<?>)tabType).name();
+    return "HOME".equals(name) || "HOME_V2".equals(name);
+  }
+
+  private static int getTargetResourceId(Context context, String name,
+                                         String type) {
+    return context.getResources().getIdentifier(
+        name, type, context.getPackageName());
+  }
+
+  private static int dpToPx(Context context, float dp) {
+    return Math.round(
+        dp * context.getResources().getDisplayMetrics().density);
   }
 }

--- a/app/src/main/java/app/zipper/knot/hooks/RemoveHeaderButtons.java
+++ b/app/src/main/java/app/zipper/knot/hooks/RemoveHeaderButtons.java
@@ -19,17 +19,20 @@ public class RemoveHeaderButtons implements BaseHook {
   @Override
   public void hook(KnotConfig config, XC_LoadPackage.LoadPackageParam lpparam)
       throws Throwable {
+    LineVersion.Config cfg = LineVersion.get();
+    if (cfg == null)
+      return;
+
     if (!config.removeAiFriendsButton.enabled &&
         !config.removeSearchBarAgentIButton.enabled &&
         !config.removeOpenChatButton.enabled)
       return;
 
     if (config.removeSearchBarAgentIButton.enabled) {
-      hookHomeSearchBarAiButton(lpparam.classLoader);
+      hookHomeSearchBarAiButton(cfg, lpparam.classLoader);
     }
 
-    LineVersion.Config cfg = LineVersion.get();
-    if (cfg == null || cfg.talkTabHeader.chatTabHeaderStateClass.isEmpty())
+    if (cfg.talkTabHeader.chatTabHeaderStateClass.isEmpty())
       return;
 
     Class<?> cls = XposedHelpers.findClass(
@@ -43,7 +46,7 @@ public class RemoveHeaderButtons implements BaseHook {
     Object openChat = safeValueOf(iconTypeCls, "OPEN_CHAT");
 
     if (config.removeSearchBarAgentIButton.enabled) {
-      hookSearchBarAiButton(cls);
+      hookSearchBarAiButton(cfg, cls);
     }
 
     XposedBridge.hookAllConstructors(cls, new XC_MethodHook() {
@@ -151,21 +154,12 @@ public class RemoveHeaderButtons implements BaseHook {
     return null;
   }
 
-  private static void hookSearchBarAiButton(Class<?> cls) {
-    Method searchBarAiVisible = null;
-    Method searchBarAiClick = null;
-
-    for (Method method : cls.getDeclaredMethods()) {
-      if (method.getParameterCount() != 0)
-        continue;
-      if (method.getName().equals("w") &&
-          method.getReturnType() == boolean.class) {
-        searchBarAiVisible = method;
-      } else if (method.getName().equals("r") &&
-                 method.getReturnType() == void.class) {
-        searchBarAiClick = method;
-      }
-    }
+  private static void hookSearchBarAiButton(LineVersion.Config cfg,
+                                            Class<?> cls) {
+    Method searchBarAiVisible = findZeroArgMethod(
+        cls, cfg.searchBarAgentI.talkVisibleMethod, boolean.class);
+    Method searchBarAiClick = findZeroArgMethod(
+        cls, cfg.searchBarAgentI.talkClickMethod, void.class);
 
     if (searchBarAiVisible != null) {
       XposedBridge.hookMethod(searchBarAiVisible, new XC_MethodHook() {
@@ -199,10 +193,29 @@ public class RemoveHeaderButtons implements BaseHook {
     }
   }
 
-  private static void hookHomeSearchBarAiButton(ClassLoader classLoader) {
+  private static Method findZeroArgMethod(Class<?> cls, String methodName,
+                                          Class<?> returnType) {
+    if (methodName == null || methodName.isEmpty())
+      return null;
+    try {
+      Method method = cls.getDeclaredMethod(methodName);
+      if (method.getReturnType() == returnType)
+        return method;
+    } catch (NoSuchMethodException e) {
+    }
+    return null;
+  }
+
+  private static void hookHomeSearchBarAiButton(LineVersion.Config cfg,
+                                                ClassLoader classLoader) {
+    if (cfg.searchBarAgentI.homeSearchBarClass.isEmpty() ||
+        cfg.searchBarAgentI.homeRefreshMethod.isEmpty())
+      return;
+
     Class<?> cls;
     try {
-      cls = XposedHelpers.findClass("ni4.h", classLoader);
+      cls = XposedHelpers.findClass(
+          cfg.searchBarAgentI.homeSearchBarClass, classLoader);
     } catch (Throwable t) {
       XposedBridge.log(
           "Knot: RemoveHeaderButtons could not find Home search bar class.");
@@ -216,7 +229,7 @@ public class RemoveHeaderButtons implements BaseHook {
         if (!Main.options.removeSearchBarAgentIButton.enabled)
           return;
         try {
-          patchHomeSearchBarAiButton(param.thisObject);
+          patchHomeSearchBarAiButton(cfg, param.thisObject);
         } catch (Exception e) {
           XposedBridge.log(
               "Knot: RemoveHeaderButtons Home search bar error: " + e);
@@ -225,22 +238,24 @@ public class RemoveHeaderButtons implements BaseHook {
     };
 
     XposedBridge.hookAllConstructors(cls, patchHook);
-    XposedBridge.hookAllMethods(cls, "e", patchHook);
+    XposedBridge.hookAllMethods(
+        cls, cfg.searchBarAgentI.homeRefreshMethod, patchHook);
     XposedBridge.log(
         "Knot: RemoveHeaderButtons hooked Home search bar Agent i button.");
   }
 
-  private static void patchHomeSearchBarAiButton(Object instance) {
-    if (!isHomeSearchBar(instance))
+  private static void patchHomeSearchBarAiButton(LineVersion.Config cfg,
+                                                 Object instance) {
+    if (!isHomeSearchBar(cfg, instance))
       return;
 
-    View rootView = (View)XposedHelpers.getObjectField(instance, "c");
+    View rootView = (View)XposedHelpers.getObjectField(
+        instance, cfg.searchBarAgentI.homeRootViewField);
     if (rootView == null)
       return;
 
     Context context = rootView.getContext();
-    int aiContainerId = getTargetResourceId(
-        context, "main_tab_ai_entry_icon_container", "id");
+    int aiContainerId = cfg.searchBarAgentI.homeAiContainerId;
     if (aiContainerId == 0)
       return;
 
@@ -252,29 +267,30 @@ public class RemoveHeaderButtons implements BaseHook {
     aiContainer.setClickable(false);
     aiContainer.setVisibility(View.GONE);
 
-    int guidelineId = getTargetResourceId(context, "main_tab_guideline", "id");
+    int guidelineId = cfg.searchBarAgentI.homeGuidelineId;
     View guidelineView =
         guidelineId != 0 ? rootView.findViewById(guidelineId) : null;
-    if (guidelineView instanceof Guideline)
-      ((Guideline)guidelineView).setGuidelineEnd(dpToPx(context, 55f));
+    if (guidelineView instanceof Guideline &&
+        cfg.searchBarAgentI.homeGuidelineEndDp > 0)
+      ((Guideline)guidelineView).setGuidelineEnd(
+          dpToPx(context, cfg.searchBarAgentI.homeGuidelineEndDp));
   }
 
-  private static boolean isHomeSearchBar(Object instance) {
-    Object tabType = XposedHelpers.getObjectField(instance, "b");
+  private static boolean isHomeSearchBar(LineVersion.Config cfg,
+                                         Object instance) {
+    if (cfg.searchBarAgentI.homeTabTypeField.isEmpty())
+      return false;
+
+    Object tabType = XposedHelpers.getObjectField(
+        instance, cfg.searchBarAgentI.homeTabTypeField);
     if (!(tabType instanceof Enum<?>))
       return false;
     String name = ((Enum<?>)tabType).name();
-    return "HOME".equals(name) || "HOME_V2".equals(name);
+    return name.equals(cfg.searchBarAgentI.homeTabName) ||
+        name.equals(cfg.searchBarAgentI.homeTabV2Name);
   }
 
-  private static int getTargetResourceId(Context context, String name,
-                                         String type) {
-    return context.getResources().getIdentifier(
-        name, type, context.getPackageName());
-  }
-
-  private static int dpToPx(Context context, float dp) {
-    return Math.round(
-        dp * context.getResources().getDisplayMetrics().density);
+  private static int dpToPx(Context context, int dp) {
+    return Math.round(dp * context.getResources().getDisplayMetrics().density);
   }
 }

--- a/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
+++ b/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
@@ -205,6 +205,10 @@ public class ModuleStrings {
       "AI Friendsボタンを非表示";
   public static final String OPT_REMOVE_AI_FRIENDS_BUTTON_DESC =
       "トークタブ右上の「AI Friends」ボタンを非表示にします。";
+  public static final String OPT_REMOVE_SEARCH_BAR_AGENT_I_BUTTON_LABEL =
+      "検索バーのAgent iボタンを非表示";
+  public static final String OPT_REMOVE_SEARCH_BAR_AGENT_I_BUTTON_DESC =
+      "トークタブ/ホームタブの検索バー右側にある「Agent i」ボタンを非表示にします。";
   public static final String OPT_REMOVE_OPEN_CHAT_BUTTON_LABEL =
       "オープンチャットボタンを非表示";
   public static final String OPT_REMOVE_OPEN_CHAT_BUTTON_DESC =

--- a/app/src/main/java/app/zipper/knot/versions/Version266.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version266.java
@@ -253,6 +253,18 @@ public class Version266 {
     v.talkTabHeader.iconTypeClass = "yu0.n";
     v.talkTabHeader.iconTypeFieldInButton = "a";
 
+    v.searchBarAgentI.talkVisibleMethod = "w";
+    v.searchBarAgentI.talkClickMethod = "r";
+    v.searchBarAgentI.homeSearchBarClass = "ni4.h";
+    v.searchBarAgentI.homeRefreshMethod = "e";
+    v.searchBarAgentI.homeRootViewField = "c";
+    v.searchBarAgentI.homeTabTypeField = "b";
+    v.searchBarAgentI.homeTabName = "HOME";
+    v.searchBarAgentI.homeTabV2Name = "HOME_V2";
+    v.searchBarAgentI.homeAiContainerId = 0x7f0b16db;
+    v.searchBarAgentI.homeGuidelineId = 0x7f0b16dd;
+    v.searchBarAgentI.homeGuidelineEndDp = 55;
+
     v.aiIcon.repoClass = "yw0.c";
     v.aiIcon.methodGetShownAfterMillis = "i";
 


### PR DESCRIPTION
## 概要
LINE 26.6.0 において、トークタブ / ホームタブの検索バー右側に表示される `Agent i` ボタンを非表示にする設定を追加しました。
<img width="1080" height="640" alt="Screenshot_2026-05-04-05-46-38-153_jp naver line android-edit" src="https://github.com/user-attachments/assets/bab7c85d-3a02-404d-87de-b8e0c7c0e05d" />
<img width="1080" height="344" alt="Screenshot_2026-05-04-05-46-54-796_jp naver line android-edit" src="https://github.com/user-attachments/assets/d562b1f4-4a59-4791-bc38-63137161ef02" />
<img width="1080" height="246" alt="Screenshot_2026-05-04-05-47-05-989_jp naver line android-edit" src="https://github.com/user-attachments/assets/e3a5da44-f5da-4fa5-8b5b-b579bb552347" />

既存の `AI Friends` 非表示機能とは別機能として分離しています。

  ## 変更内容
  - `検索バーのAgent iボタンを非表示` 設定を追加
  - トークタブ検索バーの `Agent i` ボタンをフックで無効化
  - ホームタブ検索バーの `Agent i` ボタンをフックで無効化

  ## 実装方針
  - 表示判定とクリック導線を Knot 側でフックして無効化
  - ホーム側は検索バーの `Agent i` コンテナを非表示化し、レイアウト崩れを避けるためガイドライン位置も補正

  ## 確認項目
  - `./gradlew assembleDebug` でビルド成功確認
  - 追加した`Agent i` 項目が別設定として表示されることを確認
  - 新規設定有効時に、トークタブ / ホームタブの検索バー右側の `Agent i` ボタンが非表示になることを確認