### PR TITLE
feat: LYPアコーディオンの非表示オプションを追加

### DIFF
--- a/app/src/main/java/app/zipper/knot/KnotConfig.java
+++ b/app/src/main/java/app/zipper/knot/KnotConfig.java
@@ -70,6 +70,11 @@ public class KnotConfig {
       "remove_home_services", ModuleStrings.OPT_REMOVE_HOME_SERVICES_LABEL,
       ModuleStrings.OPT_REMOVE_HOME_SERVICES_DESC, false, Category.DISPLAY);
 
+  public Item removeHomeAccordion = new Item(
+      "remove_home_accordion",
+      ModuleStrings.OPT_REMOVE_HOME_ACCORDION_LABEL,
+      ModuleStrings.OPT_REMOVE_HOME_ACCORDION_DESC, false, Category.DISPLAY);
+
   public Item preventMarkAsRead = new Item(
       "prevent_mark_as_read", ModuleStrings.OPT_PREVENT_MARK_AS_READ_LABEL,
       ModuleStrings.OPT_PREVENT_MARK_AS_READ_DESC, false, Category.CHAT);
@@ -157,6 +162,7 @@ public class KnotConfig {
                          hideTabText,
                          removeHomeRecommendations,
                          removeHomeServices,
+                         removeHomeAccordion,
                          useCustomFont,
                          customFontPath,
                          preventMarkAsRead,

--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -201,6 +201,11 @@ public class LineVersion {
       public String resServiceCarouselId = "";
       public String resServiceTitleId = "";
       public String resNoServicesId = "";
+      public String lypRecommendationModuleArgClass = "";
+      public String lypRecommendationContextClass = "";
+      public String lypRecommendationComposerClass = "";
+      public String lypRecommendationModuleClass = "";
+      public String lypRecommendationControllerClass = "";
     }
 
     public static class Chat {

--- a/app/src/main/java/app/zipper/knot/hooks/RemoveHeaderButtons.java
+++ b/app/src/main/java/app/zipper/knot/hooks/RemoveHeaderButtons.java
@@ -39,8 +39,7 @@ public class RemoveHeaderButtons implements BaseHook {
     Class<?> iconTypeCls = XposedHelpers.findClass(
         cfg.talkTabHeader.iconTypeClass, lpparam.classLoader);
 
-    final Object aiFriend =
-        firstAvailableValueOf(iconTypeCls, "AI_FRIEND", "AI_FRIENDS");
+    final Object aiFriend = firstAvailableValueOf(iconTypeCls, "AI_FRIEND", "AI_FRIENDS");
     Object album = safeValueOf(iconTypeCls, "ALBUM");
     Object openChat = safeValueOf(iconTypeCls, "OPEN_CHAT");
 
@@ -68,7 +67,7 @@ public class RemoveHeaderButtons implements BaseHook {
         if (!Main.options.removeAiFriendsButton.enabled &&
             !Main.options.removeOpenChatButton.enabled)
           return;
-        List<?> result = (List<?>)param.getResult();
+        List<?> result = (List<?>) param.getResult();
         if (result == null || result.isEmpty())
           return;
         try {
@@ -83,18 +82,18 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static void patchState(Object instance, LineVersion.Config cfg,
-                                 Object aiFriend, Object album, Object openChat)
+      Object aiFriend, Object album, Object openChat)
       throws Exception {
     Object iconState = XposedHelpers.getObjectField(
         instance, cfg.talkTabHeader.iconListStateField);
-    List<?> icons = (List<?>)XposedHelpers.callMethod(iconState, "getValue");
+    List<?> icons = (List<?>) XposedHelpers.callMethod(iconState, "getValue");
     if (icons != null)
       XposedHelpers.callMethod(iconState, "setValue",
-                               filterIcons(icons, aiFriend, album, openChat));
+          filterIcons(icons, aiFriend, album, openChat));
 
     Object btnState = XposedHelpers.getObjectField(
         instance, cfg.talkTabHeader.buttonListStateField);
-    List<?> buttons = (List<?>)XposedHelpers.callMethod(btnState, "getValue");
+    List<?> buttons = (List<?>) XposedHelpers.callMethod(btnState, "getValue");
     if (buttons != null)
       XposedHelpers.callMethod(
           btnState, "setValue",
@@ -102,7 +101,7 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static List<Object> filterIcons(List<?> icons, Object aiFriend,
-                                          Object album, Object openChat) {
+      Object album, Object openChat) {
     boolean removeAi = Main.options.removeAiFriendsButton.enabled;
     boolean removeOc = Main.options.removeOpenChatButton.enabled;
     List<Object> out = new ArrayList<>();
@@ -117,9 +116,9 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static List<Object> filterButtons(List<?> buttons,
-                                            LineVersion.Config cfg,
-                                            Object aiFriend, Object album,
-                                            Object openChat) throws Exception {
+      LineVersion.Config cfg,
+      Object aiFriend, Object album,
+      Object openChat) throws Exception {
     boolean removeAi = Main.options.removeAiFriendsButton.enabled;
     boolean removeOc = Main.options.removeOpenChatButton.enabled;
     List<Object> out = new ArrayList<>();
@@ -153,11 +152,10 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static void hookSearchBarAiButton(LineVersion.Config cfg,
-                                            Class<?> cls) {
+      Class<?> cls) {
     Method searchBarAiVisible = findZeroArgMethod(
         cls, cfg.searchBarAgentI.talkVisibleMethod, boolean.class);
-    Method searchBarAiClick =
-        findZeroArgMethod(cls, cfg.searchBarAgentI.talkClickMethod, void.class);
+    Method searchBarAiClick = findZeroArgMethod(cls, cfg.searchBarAgentI.talkClickMethod, void.class);
 
     if (searchBarAiVisible != null) {
       XposedBridge.hookMethod(searchBarAiVisible, new XC_MethodHook() {
@@ -170,7 +168,7 @@ public class RemoveHeaderButtons implements BaseHook {
       });
     } else {
       XposedBridge.log("Knot: RemoveHeaderButtons could not find search bar AI "
-                       + "visibility method.");
+          + "visibility method.");
     }
 
     if (searchBarAiClick != null) {
@@ -191,7 +189,7 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static Method findZeroArgMethod(Class<?> cls, String methodName,
-                                          Class<?> returnType) {
+      Class<?> returnType) {
     if (methodName == null || methodName.isEmpty())
       return null;
     try {
@@ -204,7 +202,7 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static void hookHomeSearchBarAiButton(LineVersion.Config cfg,
-                                                ClassLoader classLoader) {
+      ClassLoader classLoader) {
     if (cfg.searchBarAgentI.homeSearchBarClass.isEmpty() ||
         cfg.searchBarAgentI.homeRefreshMethod.isEmpty())
       return;
@@ -212,7 +210,7 @@ public class RemoveHeaderButtons implements BaseHook {
     Class<?> cls;
     try {
       cls = XposedHelpers.findClass(cfg.searchBarAgentI.homeSearchBarClass,
-                                    classLoader);
+          classLoader);
     } catch (Throwable t) {
       XposedBridge.log(
           "Knot: RemoveHeaderButtons could not find Home search bar class.");
@@ -228,24 +226,24 @@ public class RemoveHeaderButtons implements BaseHook {
           patchHomeSearchBarAiButton(cfg, param.thisObject);
         } catch (Exception e) {
           XposedBridge.log("Knot: RemoveHeaderButtons Home search bar error: " +
-                           e);
+              e);
         }
       }
     };
 
     XposedBridge.hookAllConstructors(cls, patchHook);
     XposedBridge.hookAllMethods(cls, cfg.searchBarAgentI.homeRefreshMethod,
-                                patchHook);
+        patchHook);
     XposedBridge.log(
         "Knot: RemoveHeaderButtons hooked Home search bar Agent i button.");
   }
 
   private static void patchHomeSearchBarAiButton(LineVersion.Config cfg,
-                                                 Object instance) {
+      Object instance) {
     if (!isHomeSearchBar(cfg, instance))
       return;
 
-    View rootView = (View)XposedHelpers.getObjectField(
+    View rootView = (View) XposedHelpers.getObjectField(
         instance, cfg.searchBarAgentI.homeRootViewField);
     if (rootView == null)
       return;
@@ -264,11 +262,10 @@ public class RemoveHeaderButtons implements BaseHook {
     aiContainer.setVisibility(View.GONE);
 
     int guidelineId = cfg.searchBarAgentI.homeGuidelineId;
-    View guidelineView =
-        guidelineId != 0 ? rootView.findViewById(guidelineId) : null;
+    View guidelineView = guidelineId != 0 ? rootView.findViewById(guidelineId) : null;
     if (guidelineView != null && cfg.searchBarAgentI.homeGuidelineEndDp > 0) {
       if (cfg.searchBarAgentI.homeGuidelineClass.equals(
-              guidelineView.getClass().getName())) {
+          guidelineView.getClass().getName())) {
         try {
           XposedHelpers.callMethod(
               guidelineView, "setGuidelineEnd",
@@ -281,7 +278,7 @@ public class RemoveHeaderButtons implements BaseHook {
   }
 
   private static boolean isHomeSearchBar(LineVersion.Config cfg,
-                                         Object instance) {
+      Object instance) {
     if (cfg.searchBarAgentI.homeTabTypeField.isEmpty())
       return false;
 
@@ -289,7 +286,7 @@ public class RemoveHeaderButtons implements BaseHook {
         instance, cfg.searchBarAgentI.homeTabTypeField);
     if (!(tabType instanceof Enum<?>))
       return false;
-    String name = ((Enum<?>)tabType).name();
+    String name = ((Enum<?>) tabType).name();
     return name.equals(cfg.searchBarAgentI.homeTabName) ||
         name.equals(cfg.searchBarAgentI.homeTabV2Name);
   }

--- a/app/src/main/java/app/zipper/knot/hooks/RemoveHomeContents.java
+++ b/app/src/main/java/app/zipper/knot/hooks/RemoveHomeContents.java
@@ -17,6 +17,7 @@ public class RemoveHomeContents implements BaseHook {
   private static int svcTitleId = 0;
   private static int noServicesId = 0;
   private static boolean isSetupDone = false;
+  private static Object emptySectionInstance = null;
 
   @Override
   public void hook(KnotConfig config, XC_LoadPackage.LoadPackageParam lpparam)
@@ -81,6 +82,36 @@ public class RemoveHomeContents implements BaseHook {
             }
           }
         });
+
+    LineVersion.Config c = LineVersion.get();
+    if (c == null || c.home.lypRecommendationControllerClass.isEmpty() ||
+        c.home.lypRecommendationModuleArgClass.isEmpty() ||
+        c.home.lypRecommendationContextClass.isEmpty() ||
+        c.home.lypRecommendationComposerClass.isEmpty())
+      return;
+
+    XposedHelpers.findAndHookMethod(
+        c.home.lypRecommendationControllerClass, lpparam.classLoader, "a",
+        String.class, c.home.lypRecommendationModuleArgClass,
+        c.home.lypRecommendationContextClass,
+        c.home.lypRecommendationComposerClass, new XC_MethodHook() {
+          @Override
+          protected void beforeHookedMethod(MethodHookParam param)
+              throws Throwable {
+            if (!SettingsStore.get(config.removeHomeAccordion.key,
+                                   config.removeHomeAccordion.enabled))
+              return;
+
+            Object module = param.args[1];
+            if (module == null ||
+                !module.getClass()
+                     .getName()
+                     .equals(c.home.lypRecommendationModuleClass))
+              return;
+
+            param.setResult(getEmptySectionInstance(lpparam.classLoader));
+          }
+        });
   }
 
   private static void hideView(View target) {
@@ -90,5 +121,14 @@ public class RemoveHomeContents implements BaseHook {
       params.height = 0;
       target.setLayoutParams(params);
     }
+  }
+
+  private static Object getEmptySectionInstance(ClassLoader classLoader) {
+    if (emptySectionInstance != null)
+      return emptySectionInstance;
+    Class<?> sectionClass = XposedHelpers.findClass("l02.e", classLoader);
+    emptySectionInstance =
+        XposedHelpers.getStaticObjectField(sectionClass, "e");
+    return emptySectionInstance;
   }
 }

--- a/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
+++ b/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
@@ -120,6 +120,11 @@ public class ModuleStrings {
       "ホームのサービスを非表示";
   public static final String OPT_REMOVE_HOME_SERVICES_DESC =
       "ホーム画面に表示されるサービス一覧を非表示にします。";
+  public static final String OPT_REMOVE_HOME_ACCORDION_LABEL =
+      "ホーム上部のアコーディオンを非表示";
+  public static final String OPT_REMOVE_HOME_ACCORDION_DESC =
+      "ホームタブ上部（検索バーと友達リストの間）に表示されるLYP特典などの"
+      + "アコーディオン枠を非表示にします。";
   public static final String OPT_REMOVE_TAB_VOOM_LABEL = "VOOMタブを非表示";
   public static final String OPT_REMOVE_TAB_VOOM_DESC =
       "下部のVOOMタブを隠します。";

--- a/app/src/main/java/app/zipper/knot/versions/Version266.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version266.java
@@ -163,6 +163,11 @@ public class Version266 {
     v.home.resServiceCarouselId = "home_tab_service_carousel";
     v.home.resServiceTitleId = "home_tab_service_title";
     v.home.resNoServicesId = "home_tab_no_services_title";
+    v.home.lypRecommendationModuleArgClass = "my1.r";
+    v.home.lypRecommendationContextClass = "v02.g";
+    v.home.lypRecommendationComposerClass = "t2.k";
+    v.home.lypRecommendationModuleClass = "my1.r$d0";
+    v.home.lypRecommendationControllerClass = "p32.k";
 
     v.chat.headerController = "h81.m1";
     v.chat.headerHelper = "jp.naver.line.android.common.view.header.b";


### PR DESCRIPTION
## 概要
LINE 26.6.0 において、ホームタブの検索バーと友達リストの間に表示されるLYP関連のアコーディオンを削除する機能を追加しました。
<img width="1080" height="327" alt="Screenshot_2026-05-05-04-51-51-711_jp naver line android-edit" src="https://github.com/user-attachments/assets/75306f59-a921-4648-9461-bbc47497c6b0" />
<img width="1080" height="229" alt="Screenshot_2026-05-05-04-52-37-544_jp naver line android-edit" src="https://github.com/user-attachments/assets/6fe72337-c1d6-4a97-8089-8bb8d3cf3091" />



  ## 変更内容
  - `ホーム上部のアコーディオンを非表示` 設定を追加
<img width="1080" height="257" alt="Screenshot_2026-05-05-04-52-10-985_jp naver line android-edit" src="https://github.com/user-attachments/assets/408e3e62-e29e-41a0-a78d-5899ddc94b1e" />

  - `lypRecommendation`(LYPアコーディオン)をフックで無効化

- 既存コードのフォーマット

  ## 確認項目
 - `./gradlew assembleDebug` でビルド成功確認
 - 追加した設定項目が表示されることを確認
 - 新規設定有効時に、ホームタブのLYPアコーディオンが表示されないことを確認