### PR TITLE
feat: トークルームメニュー内のAgent iトグル非表示設定を追加 

### DIFF
--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -28,6 +28,7 @@ public class LineVersion {
     public Notification notification = new Notification();
     public TalkTabHeader talkTabHeader = new TalkTabHeader();
     public SearchBarAgentI searchBarAgentI = new SearchBarAgentI();
+    public AgentIInChat agentIInChat = new AgentIInChat();
     public AiIcon aiIcon = new AiIcon();
 
     public static class Main {
@@ -319,6 +320,10 @@ public class LineVersion {
       public int homeGuidelineId = 0;
       public int homeGuidelineEndDp = 0;
       public String homeGuidelineClass = "";
+    }
+
+    public static class AgentIInChat {
+      public String toggleComposableClass = "";
     }
 
     public static class AiIcon {

--- a/app/src/main/java/app/zipper/knot/Main.java
+++ b/app/src/main/java/app/zipper/knot/Main.java
@@ -79,6 +79,7 @@ public class Main
                           new FontUnlockHook(),
                           new BackupRestoreHook(),
                           new FixNotificationHook(),
+                          new RemoveTalkRoomAgentIToggle(),
                           new HideAiIconPermanently()};
 
       for (BaseHook h : hooks) {

--- a/app/src/main/java/app/zipper/knot/hooks/RemoveTalkRoomAgentIToggle.java
+++ b/app/src/main/java/app/zipper/knot/hooks/RemoveTalkRoomAgentIToggle.java
@@ -1,0 +1,81 @@
+package app.zipper.knot.hooks;
+
+import app.zipper.knot.KnotConfig;
+import app.zipper.knot.LineVersion;
+import app.zipper.knot.Main;
+import app.zipper.knot.SettingsStore;
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class RemoveTalkRoomAgentIToggle implements BaseHook {
+
+  private static final String LEGACY_KEY = "remove_talkroom_agent_i_toggle";
+
+  @Override
+  public void hook(KnotConfig config, XC_LoadPackage.LoadPackageParam lpparam)
+      throws Throwable {
+    if (!isEnabled(config))
+      return;
+
+    LineVersion.Config cfg = LineVersion.get();
+    if (cfg == null || cfg.agentIInChat.toggleComposableClass.isEmpty())
+      return;
+
+    final Class<?> cls;
+    try {
+      cls = XposedHelpers.findClass(cfg.agentIInChat.toggleComposableClass,
+          lpparam.classLoader);
+    } catch (Throwable t) {
+      return;
+    }
+
+    XC_MethodHook noOp = new XC_MethodHook() {
+      @Override
+      protected void beforeHookedMethod(MethodHookParam param) {
+        if (!isEnabled(Main.options))
+          return;
+        param.setResult(null);
+      }
+    };
+
+    int hookCount = 0;
+    for (Method method : cls.getDeclaredMethods()) {
+      if (!isComposeRenderMethod(method))
+        continue;
+      XposedBridge.hookMethod(method, noOp);
+      hookCount++;
+    }
+
+    if (hookCount > 0) {
+      XposedBridge.log("Knot: RemoveTalkRoomAgentIToggle hooked " + hookCount +
+          " compose methods.");
+    }
+  }
+
+  private static boolean isEnabled(KnotConfig config) {
+    return config.removeSearchBarAgentIButton.enabled ||
+        SettingsStore.get(LEGACY_KEY, false);
+  }
+
+  private static boolean isComposeRenderMethod(Method method) {
+    if (!Modifier.isStatic(method.getModifiers()) ||
+        method.getReturnType() != Void.TYPE) {
+      return false;
+    }
+
+    boolean hasComposer = false;
+    boolean hasFlags = false;
+    for (Class<?> type : method.getParameterTypes()) {
+      if ("t2.k".equals(type.getName())) {
+        hasComposer = true;
+      } else if (type == Integer.TYPE) {
+        hasFlags = true;
+      }
+    }
+    return hasComposer && hasFlags;
+  }
+}

--- a/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
+++ b/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
@@ -108,7 +108,6 @@ public class ModuleStrings {
       "チャット画面のテキストボックス内にあるAIアイコンを常に非表示に"
       + "します。通常は30日間のみ非表示にできますが、このオプションを有効にする"
       + "と設定に関わらず永続的に非表示になります。";
-
   public static final String OPT_REMOVE_ADS_LABEL = "広告を非表示";
   public static final String OPT_REMOVE_ADS_DESC =
       "トークリスト上部やホーム画面などに表示される広告を非表示にします。";
@@ -211,9 +210,11 @@ public class ModuleStrings {
   public static final String OPT_REMOVE_AI_FRIENDS_BUTTON_DESC =
       "トークタブ右上の「AI Friends」ボタンを非表示にします。";
   public static final String OPT_REMOVE_SEARCH_BAR_AGENT_I_BUTTON_LABEL =
-      "検索バーのAgent iボタンを非表示";
+      "Agent i関連のボタンを非表示";
   public static final String OPT_REMOVE_SEARCH_BAR_AGENT_I_BUTTON_DESC =
-      "トークタブ/ホームタブの検索バー右側にある「Agent i」ボタンを非表示にします。";
+      "トークタブ/ホームタブの検索バー右側にある「Agent i」ボタンと、"
+      + "トークルーム内の「+」メニューにある"
+      + "「トークルームのAgent iを表示」トグルをまとめて非表示にします。";
   public static final String OPT_REMOVE_OPEN_CHAT_BUTTON_LABEL =
       "オープンチャットボタンを非表示";
   public static final String OPT_REMOVE_OPEN_CHAT_BUTTON_DESC =

--- a/app/src/main/java/app/zipper/knot/versions/Version266.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version266.java
@@ -272,6 +272,8 @@ public class Version266 {
     v.searchBarAgentI.homeGuidelineClass =
         "androidx.constraintlayout.widget.Guideline";
 
+    v.agentIInChat.toggleComposableClass = "za1.h";
+
     v.aiIcon.repoClass = "yw0.c";
     v.aiIcon.methodGetShownAfterMillis = "i";
 


### PR DESCRIPTION
## 概要
LINE 26.6.0 において、トークルーム内の+メニュー内の 「トークルームのAgent iを表示」というトグルボタンを非表示にする設定を追加しました。
<img width="1080" height="253" alt="Screenshot_2026-05-05-14-32-43-112_jp naver line android-edit" src="https://github.com/user-attachments/assets/81945e80-3cdc-4462-b459-f5c9fd8ec0e6" />
<img width="1080" height="1114" alt="Screenshot_2026-05-05-11-50-27-108_jp naver line android-edit" src="https://github.com/user-attachments/assets/f95c2261-1e3b-4a92-8629-134263d55328" />


#1 と設定を共通化しています。

  ## 変更内容
   - トークルーム内の+メニュー内の 「トークルームのAgent iを表示」というトグルボタンをフックで無効化出来るように変更。

 
  ## 確認項目
  - `./gradlew assembleDebug` でビルド成功確認
  - 既存の設定を有効にしたままアップデートし、 #1 との設定と同時に機能が有効になっているかを確認
  - 新規設定有効時に、当該トグルボタンが非表示になることを確認