### PR TITLE
サブ端末でも一部の機能が動作するように

### DIFF
--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -14,6 +14,7 @@ public class LineVersion {
     public Main main = new Main();
     public Settings settings = new Settings();
     public PlusMenu plusMenu = new PlusMenu();
+    public ChatListMoreMenu chatListMoreMenu = new ChatListMoreMenu();
     public Unsend unsend = new Unsend();
     public Thrift thrift = new Thrift();
     public Tabs tabs = new Tabs();
@@ -181,6 +182,15 @@ public class LineVersion {
       public String editChatDrawable = "";
       public String moduleId = "app.zipper.knot";
       public String targetPkg = "jp.naver.line.android";
+    }
+
+    public static class ChatListMoreMenu {
+      public String popupListViewClass = "";
+      public String fieldListView = "";
+      public String popupListAdapterClass = "";
+      public String fieldPopupItems = "";
+      public String clickListenerClass = "";
+      public String methodAddItem = "";
     }
 
     public static class ReadReceipt {

--- a/app/src/main/java/app/zipper/knot/Main.java
+++ b/app/src/main/java/app/zipper/knot/Main.java
@@ -76,6 +76,7 @@ public class Main extends XposedModule {
       if (options.recordReadHistory.enabled || options.preventMarkAsRead.enabled) {
         applyHook(new ReadReceiptHandler(), lpparam);
         applyHook(new PlusMenuHook(), lpparam);
+        applyHook(new ChatListMoreMenuHook(), lpparam);
       }
       if (options.recordReadHistory.enabled) {
         applyHook(new HeaderButtonInjector(), lpparam);

--- a/app/src/main/java/app/zipper/knot/hooks/ChatListMoreMenuHook.java
+++ b/app/src/main/java/app/zipper/knot/hooks/ChatListMoreMenuHook.java
@@ -1,0 +1,197 @@
+package app.zipper.knot.hooks;
+
+import android.util.Pair;
+import android.view.View;
+import android.widget.Adapter;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import app.zipper.knot.Knot;
+import app.zipper.knot.KnotConfig;
+import app.zipper.knot.LineVersion;
+import app.zipper.knot.LoadParam;
+import app.zipper.knot.Reflect;
+import app.zipper.knot.SettingsStore;
+import app.zipper.knot.utils.ModuleStrings;
+import java.util.List;
+
+public class ChatListMoreMenuHook implements BaseHook {
+
+  private static final int TAG_CLICK_WRAPPED = 0x64010006;
+
+  @Override
+  public void hook(KnotConfig options, LoadParam lpparam) throws Throwable {
+    LineVersion.Config cfg = LineVersion.get();
+    if (cfg.chatListMoreMenu.popupListViewClass.isEmpty()
+        || cfg.chatListMoreMenu.fieldListView.isEmpty()
+        || cfg.chatListMoreMenu.popupListAdapterClass.isEmpty()
+        || cfg.chatListMoreMenu.fieldPopupItems.isEmpty()
+        || cfg.chatListMoreMenu.clickListenerClass.isEmpty()
+        || cfg.chatListMoreMenu.methodAddItem.isEmpty()) {
+      return;
+    }
+    Class<?> popupCls =
+        Reflect.findClass(cfg.chatListMoreMenu.popupListViewClass, lpparam.classLoader);
+
+    Knot.module
+        .hook(
+            Reflect.findMethodExact(
+                popupCls, "setOnItemClickListener", AdapterView.OnItemClickListener.class))
+        .intercept(
+            chain -> {
+              Object result = chain.proceed();
+              Object listener = chain.getArg(0);
+              if (isTargetOriginalListener(listener)) {
+                installClickWrapperIfNeeded(
+                    chain.getThisObject(), (AdapterView.OnItemClickListener) listener);
+              }
+              return result;
+            });
+
+    Knot.module
+        .hook(
+            Reflect.findMethodExact(
+                popupCls, cfg.chatListMoreMenu.methodAddItem, String.class, int.class, boolean.class))
+        .intercept(
+            chain -> {
+              Object result = chain.proceed();
+              injectPairItems(chain.getThisObject(), (boolean) chain.getArg(2));
+              return result;
+            });
+  }
+
+  private static void installClickWrapperIfNeeded(
+      Object popupListView, AdapterView.OnItemClickListener original) {
+    ListView listView = getListView(popupListView);
+    if (listView == null || Boolean.TRUE.equals(listView.getTag(TAG_CLICK_WRAPPED))) return;
+    listView.setOnItemClickListener(new KnotMoreMenuClickListener(original));
+    listView.setTag(TAG_CLICK_WRAPPED, Boolean.TRUE);
+    injectPairItems(popupListView, true);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static boolean injectPairItems(Object popupListView, boolean notify) {
+    try {
+      LineVersion.Config cfg = LineVersion.get();
+      ListView listView = getListView(popupListView);
+      if (listView == null) return false;
+      if (!Boolean.TRUE.equals(listView.getTag(TAG_CLICK_WRAPPED))) return false;
+      ListAdapter adapter = listView.getAdapter();
+      if (!isTargetAdapter(adapter)) return false;
+
+      Object itemsObj = Reflect.getObjectField(adapter, cfg.chatListMoreMenu.fieldPopupItems);
+      if (!(itemsObj instanceof List)) return false;
+
+      List<Object> items = (List<Object>) itemsObj;
+      removeKnotPairs(items);
+      if (!hasOriginalPair(items)) return false;
+
+      boolean readOn = SettingsStore.get("prevent_read_state", true);
+      boolean markOn = SettingsStore.get("send_mark_state", false);
+      items.add(new Pair<>(-1, ModuleStrings.LABEL_PREVENT_READ + ": " + (readOn ? "ON" : "OFF")));
+      if (readOn) {
+        items.add(
+            new Pair<>(
+                -1, ModuleStrings.LABEL_SEND_MARK_READ + ": " + (markOn ? "ON" : "OFF")));
+      }
+
+      if (notify && adapter instanceof BaseAdapter) {
+        ((BaseAdapter) adapter).notifyDataSetChanged();
+      }
+      return true;
+    } catch (Throwable t) {
+      Knot.log("Knot: ChatListMoreMenu model inject error: " + t);
+      return false;
+    }
+  }
+
+  private static ListView getListView(Object popupListView) {
+    try {
+      LineVersion.Config cfg = LineVersion.get();
+      Object listView = Reflect.getObjectField(popupListView, cfg.chatListMoreMenu.fieldListView);
+      return listView instanceof ListView ? (ListView) listView : null;
+    } catch (Throwable ignored) {
+      return null;
+    }
+  }
+
+  private static boolean isTargetAdapter(Object adapter) {
+    try {
+      LineVersion.Config cfg = LineVersion.get();
+      return cfg != null
+          && !cfg.chatListMoreMenu.popupListAdapterClass.isEmpty()
+          && adapter != null
+          && adapter.getClass().getName().equals(cfg.chatListMoreMenu.popupListAdapterClass);
+    } catch (Throwable ignored) {
+      return false;
+    }
+  }
+
+  private static boolean isTargetOriginalListener(Object listener) {
+    try {
+      LineVersion.Config cfg = LineVersion.get();
+      return cfg != null
+          && !cfg.chatListMoreMenu.clickListenerClass.isEmpty()
+          && listener != null
+          && listener.getClass().getName().equals(cfg.chatListMoreMenu.clickListenerClass);
+    } catch (Throwable ignored) {
+      return false;
+    }
+  }
+
+  private static boolean hasOriginalPair(List<Object> items) {
+    for (Object item : items) {
+      if (item instanceof Pair && !isKnotPair(item)) return true;
+    }
+    return false;
+  }
+
+  private static void removeKnotPairs(List<Object> items) {
+    for (int i = items.size() - 1; i >= 0; i--) {
+      if (isKnotPair(items.get(i))) items.remove(i);
+    }
+  }
+
+  private static boolean isKnotPair(Object item) {
+    if (!(item instanceof Pair)) return false;
+    Object label = ((Pair<?, ?>) item).second;
+    return label instanceof String && isKnotLabel((String) label);
+  }
+
+  private static boolean isKnotLabel(String label) {
+    return label.startsWith(ModuleStrings.LABEL_PREVENT_READ + ": ")
+        || label.startsWith(ModuleStrings.LABEL_SEND_MARK_READ + ": ");
+  }
+
+  private static class KnotMoreMenuClickListener implements AdapterView.OnItemClickListener {
+    private final AdapterView.OnItemClickListener original;
+
+    KnotMoreMenuClickListener(AdapterView.OnItemClickListener original) {
+      this.original = original;
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+      try {
+        Adapter adapter = parent.getAdapter();
+        Object item = adapter == null ? null : adapter.getItem(position);
+        if (isKnotPair(item)) {
+          String label = (String) ((Pair<?, ?>) item).second;
+          if (label.startsWith(ModuleStrings.LABEL_PREVENT_READ + ": ")) {
+            boolean current = SettingsStore.get("prevent_read_state", true);
+            SettingsStore.save("prevent_read_state", !current);
+          } else {
+            boolean current = SettingsStore.get("send_mark_state", false);
+            SettingsStore.save("send_mark_state", !current);
+          }
+          injectPairItems(parent.getParent(), true);
+          return;
+        }
+      } catch (Throwable t) {
+        Knot.log("Knot: ChatListMoreMenu click error: " + t);
+      }
+      if (original != null) original.onItemClick(parent, view, position, id);
+    }
+  }
+}

--- a/app/src/main/java/app/zipper/knot/hooks/SettingsUIInjector.java
+++ b/app/src/main/java/app/zipper/knot/hooks/SettingsUIInjector.java
@@ -115,6 +115,8 @@ public class SettingsUIInjector implements BaseHook {
 
     final Class<?> proxyInterface =
         Reflect.findClass(cfg.settings.settingsItemClass, lpparam.classLoader);
+    final Class<?> settingsSearchHelperClass =
+        Reflect.findClass(cfg.settings.settingsSearchHelperClass, lpparam.classLoader);
     Knot.module
         .hook(
             Reflect.findMethodExact(
@@ -124,14 +126,20 @@ public class SettingsUIInjector implements BaseHook {
                 Collection.class))
         .intercept(
             chain -> {
-              if (chain.getThisObject() != targetAdapter) return chain.proceed();
               LineVersion.Config c = LineVersion.get();
-              List<Object> items = new ArrayList<>((Collection<?>) chain.getArg(0));
+              Collection<?> sourceItems = (Collection<?>) chain.getArg(0);
+              if (chain.getThisObject() != targetAdapter
+                  && !settingsSearchHelperClass.isInstance(chain.getThisObject())) {
+                return chain.proceed();
+              }
+              if (containsKnotItem(sourceItems, c)) return chain.proceed();
+
+              List<Object> items = new ArrayList<>(sourceItems);
               int insertPos = items.size();
               findPosition:
               for (int i = 0; i < items.size(); i++) {
                 try {
-                  Object model = Reflect.getObjectField(items.get(i), cfg.settings.fieldItemModel);
+                  Object model = Reflect.getObjectField(items.get(i), c.settings.fieldItemModel);
                   if (model == null) continue;
                   for (java.lang.reflect.Field f : model.getClass().getDeclaredFields()) {
                     if (f.getType() == int.class) {
@@ -228,7 +236,10 @@ public class SettingsUIInjector implements BaseHook {
                 int.class))
         .intercept(
             chain -> {
-              if (chain.getThisObject() != targetAdapter) return chain.proceed();
+              if (chain.getThisObject() != targetAdapter
+                  && !settingsSearchHelperClass.isInstance(chain.getThisObject())) {
+                return chain.proceed();
+              }
               LineVersion.Config c = LineVersion.get();
               int currentPos = (int) chain.getArg(1);
               boolean ours = false;
@@ -1220,6 +1231,20 @@ public class SettingsUIInjector implements BaseHook {
           });
     } catch (Throwable ignored) {
     }
+  }
+
+  private static boolean containsKnotItem(Collection<?> items, LineVersion.Config c) {
+    if (items == null) return false;
+    for (Object item : items) {
+      try {
+        Object model = Reflect.getObjectField(item, c.settings.fieldItemModel);
+        if (model == null) continue;
+        Object tag = Reflect.getObjectField(model, c.settings.fieldModelTag);
+        if (BRAND_TAG.equals(tag)) return true;
+      } catch (Throwable ignored) {
+      }
+    }
+    return false;
   }
 
   private static void applyVisibility(View root, int viewId, int state) {

--- a/app/src/main/java/app/zipper/knot/versions/Version2671.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version2671.java
@@ -68,6 +68,15 @@ public class Version2671 {
     v.plusMenu.methodExecuteAction = "X";
     v.plusMenu.editChatDrawable = "chat_tab_ui_header_plusmenu_edit_chat";
 
+    v.chatListMoreMenu.popupListViewClass =
+        "jp.naver.line.android.common.view.listview.PopupListView";
+    v.chatListMoreMenu.fieldListView = "a";
+    v.chatListMoreMenu.popupListAdapterClass =
+        "jp.naver.line.android.common.view.listview.PopupListView$b";
+    v.chatListMoreMenu.fieldPopupItems = "a";
+    v.chatListMoreMenu.clickListenerClass = "no1.a";
+    v.chatListMoreMenu.methodAddItem = "a";
+
     v.readReceipt.readReceiptManagerClass = "du2.e";
     v.readReceipt.readReceiptQueueClass = "vf8.b";
     v.readReceipt.methodEnqueueReadReceipt = "c";


### PR DESCRIPTION
## 概要

サブ端末では動作していなかったLINEの設定にKnotの設定を埋め込む機能、トークの3点リーダ（メイン端末ではプラスメニュー）に既読回避ボタンを埋め込む機能を実装
現状ver 27.7.1のみをサポートしています
<img width="1457" height="1676" alt="Screenshot_20260613-231342_EDIT_1781360116716" src="https://github.com/user-attachments/assets/d83b360a-69b8-4545-b780-e412667e62ee" />
<img width="829" height="716" alt="Screenshot_20260613-231331_EDIT_1781360099794" src="https://github.com/user-attachments/assets/94115cdf-894c-4d99-8345-6d3abc37b9c7" />

## 確認項目
Android Studioにてビルド確認
メイン端末、サブ端末ともに新たなバグは発生していないことを確認