### PR TITLE
通知を上書きせず、まとめて見れる機能の追加

### DIFF
--- a/app/src/main/java/app/zipper/knot/KnotConfig.java
+++ b/app/src/main/java/app/zipper/knot/KnotConfig.java
@@ -85,6 +85,7 @@ public class KnotConfig {
   public final Item useAmoledTheme               = item("use_amoled_theme",                 OPT_USE_AMOLED_THEME_LABEL,                 OPT_USE_AMOLED_THEME_DESC,                 false, Category.DISPLAY,      SEC_THEME);
   public final Item showThemeOnSubDevice         = item("show_theme_on_sub_device",         OPT_SHOW_THEME_ON_SUB_DEVICE_LABEL,         OPT_SHOW_THEME_ON_SUB_DEVICE_DESC,         false, Category.DISPLAY,      SEC_THEME);
   public final Item reactionNotification         = item("reaction_notification",            OPT_REACTION_NOTIFICATION_LABEL,            OPT_REACTION_NOTIFICATION_DESC,            false, Category.NOTIFICATION, "");
+  public final Item stackMessageNotifications    = item("stack_message_notifications",      OPT_STACK_MESSAGE_NOTIFICATIONS_LABEL,      OPT_STACK_MESSAGE_NOTIFICATIONS_DESC,      false, Category.NOTIFICATION, "");
   public final Item removeNotificationMuteButton = item("remove_notification_mute_button",  OPT_REMOVE_NOTIFICATION_MUTE_BUTTON_LABEL,  OPT_REMOVE_NOTIFICATION_MUTE_BUTTON_DESC,  false, Category.NOTIFICATION, "");
   public final Item experimentalFcmFix           = item("experimental_fcm_fix",             OPT_EXPERIMENTAL_FCM_FIX_LABEL,             OPT_EXPERIMENTAL_FCM_FIX_DESC,             false, Category.NOTIFICATION, "");
   public final Item lineForegroundKeepAlive      = item("line_foreground_keep_alive",       OPT_LINE_FOREGROUND_KEEP_ALIVE_LABEL,       OPT_LINE_FOREGROUND_KEEP_ALIVE_DESC,       false, Category.NOTIFICATION, "");

--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -387,6 +387,9 @@ public class LineVersion {
     public static class Notification {
       public String chatHistoryRequestClass = "";
       public String chatHistoryActivityLaunchActivityClass = "";
+      public String messageIdExtra = "line.message.id";
+      public String messageNotificationTag = "NOTIFICATION_TAG_MESSAGE";
+      public String chatNotificationTag = "jp.naver.line.android.notification.tag.chat";
     }
 
     public static class NotificationFix {

--- a/app/src/main/java/app/zipper/knot/Main.java
+++ b/app/src/main/java/app/zipper/knot/Main.java
@@ -159,6 +159,9 @@ public class Main extends XposedModule {
       if (options.removeNotificationMuteButton.enabled) {
         applyHook(new NotificationHook(), lpparam);
       }
+      if (options.stackMessageNotifications.enabled) {
+        applyHook(new StackMessageNotificationsHook(), lpparam);
+      }
       if (options.lineForegroundKeepAlive.enabled) {
         applyHook(new LineForegroundKeepAliveHook(), lpparam);
       }

--- a/app/src/main/java/app/zipper/knot/hooks/StackMessageNotificationsHook.java
+++ b/app/src/main/java/app/zipper/knot/hooks/StackMessageNotificationsHook.java
@@ -1,0 +1,438 @@
+package app.zipper.knot.hooks;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.service.notification.StatusBarNotification;
+import app.zipper.knot.Knot;
+import app.zipper.knot.KnotConfig;
+import app.zipper.knot.LineVersion;
+import app.zipper.knot.LoadParam;
+import app.zipper.knot.Reflect;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class StackMessageNotificationsHook implements BaseHook {
+  private static final String MESSAGE_TEXT_KEY = "text";
+  private static final String MESSAGE_TIME_KEY = "time";
+  private static final String MESSAGE_SENDER_KEY = "sender";
+  private static final String MESSAGE_SENDER_PERSON_KEY = "sender_person";
+  private static final String KNOT_REACTION_CHANNEL_ID = "knot_reaction";
+  private static final int MAX_STACKED_LINES = 7;
+  private static final int MAX_CACHE_KEYS = 32;
+  private static final LinkedHashMap<NotificationKey, List<MessageLine>> stackedLines =
+      new LinkedHashMap<NotificationKey, List<MessageLine>>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<NotificationKey, List<MessageLine>> eldest) {
+          return size() > MAX_CACHE_KEYS;
+        }
+      };
+
+  @Override
+  public void hook(KnotConfig config, LoadParam lpparam) throws Throwable {
+    Knot.module
+        .hook(
+            Reflect.findMethodExact(
+                NotificationManager.class, "notify", String.class, int.class, Notification.class))
+        .intercept(
+            chain -> {
+              if (!config.stackMessageNotifications.enabled) return chain.proceed();
+
+              String tag = (String) chain.getArg(0);
+              int id = (int) chain.getArg(1);
+              Notification notification = (Notification) chain.getArg(2);
+              Notification stacked = stackMessageNotification(tag, id, notification);
+              if (stacked == notification) return chain.proceed();
+              return chain.proceed(new Object[] {tag, id, stacked});
+            });
+
+    Knot.module
+        .hook(Reflect.findMethodExact(NotificationManager.class, "cancel", String.class, int.class))
+        .intercept(
+            chain -> {
+              clearStack((String) chain.getArg(0), (int) chain.getArg(1));
+              return chain.proceed();
+            });
+
+    Knot.module
+        .hook(Reflect.findMethodExact(NotificationManager.class, "cancel", int.class))
+        .intercept(
+            chain -> {
+              clearStack(null, (int) chain.getArg(0));
+              return chain.proceed();
+            });
+
+    Knot.module
+        .hook(Reflect.findMethodExact(NotificationManager.class, "cancelAll"))
+        .intercept(
+            chain -> {
+              clearAllStacks();
+              return chain.proceed();
+            });
+  }
+
+  private static Notification stackMessageNotification(
+      String tag, int id, Notification notification) {
+    LineVersion.Config.Notification notificationConfig = LineVersion.get().notification;
+    if (!isLineMessageNotificationTag(notificationConfig, tag)) return notification;
+    if (!isLineMessageNotification(notification)) return notification;
+
+    Context context = Knot.currentApplication();
+    if (context == null) return notification;
+
+    Bundle extras = notification.extras;
+    String messageId = stringExtra(extras, notificationConfig.messageIdExtra);
+    CharSequence text = firstText(extras);
+    if (!hasText(messageId) || !hasText(text)) return notification;
+
+    NotificationKey key = new NotificationKey(tag, id);
+    MessageLine incomingLine = incomingLine(extras, messageId, text);
+    List<MessageLine> lines = mergedLines(context, key, incomingLine);
+    if (lines.size() <= 1) return notification;
+
+    try {
+      Notification.Builder builder = Notification.Builder.recoverBuilder(context, notification);
+      builder.setContentText(text);
+      if (usesMessagingStyle(lines)) {
+        builder.setStyle(messagingStyle(lines, extras));
+      } else {
+        builder.setStyle(inboxStyle(lines, extras));
+      }
+      return builder.build();
+    } catch (Throwable t) {
+      Knot.log("Knot: Failed to stack message notification: " + t);
+      return notification;
+    }
+  }
+
+  private static boolean isLineMessageNotification(Notification notification) {
+    if (notification == null) return false;
+    if ((notification.flags & Notification.FLAG_ONGOING_EVENT) != 0) return false;
+    if ((notification.flags & Notification.FLAG_FOREGROUND_SERVICE) != 0) return false;
+    if ((notification.flags & Notification.FLAG_GROUP_SUMMARY) != 0) return false;
+    if (KNOT_REACTION_CHANNEL_ID.equals(notification.getChannelId())) return false;
+
+    String category = notification.category;
+    if (Notification.CATEGORY_SERVICE.equals(category)
+        || Notification.CATEGORY_CALL.equals(category)
+        || Notification.CATEGORY_TRANSPORT.equals(category)
+        || Notification.CATEGORY_STATUS.equals(category)) {
+      return false;
+    }
+
+    return notification.extras != null;
+  }
+
+  private static synchronized List<MessageLine> mergedLines(
+      Context context, NotificationKey key, MessageLine incomingLine) {
+    List<MessageLine> lines = new ArrayList<>();
+    Notification active = findActiveNotification(context, key);
+    if (active == null) {
+      stackedLines.remove(key);
+    }
+
+    List<MessageLine> cached = stackedLines.get(key);
+    if (cached != null) {
+      for (MessageLine line : cached) {
+        addLine(lines, line);
+      }
+    }
+
+    if (active != null && active.extras != null) {
+      addMessagingLines(lines, active.extras);
+
+      CharSequence[] activeLines =
+          active.extras.getCharSequenceArray(Notification.EXTRA_TEXT_LINES);
+      if (activeLines != null) {
+        for (CharSequence line : activeLines) {
+          addLine(lines, new MessageLine(null, line, null, null, null, 0L));
+        }
+      }
+    }
+
+    addLine(lines, incomingLine);
+
+    while (lines.size() > MAX_STACKED_LINES) {
+      lines.remove(0);
+    }
+    stackedLines.put(key, new ArrayList<>(lines));
+    return lines;
+  }
+
+  private static Notification.MessagingStyle messagingStyle(
+      List<MessageLine> lines, Bundle extras) {
+    Notification.MessagingStyle style = new Notification.MessagingStyle("");
+    CharSequence conversationTitle = conversationTitle(lines, extras);
+    if (hasText(conversationTitle)) style.setConversationTitle(conversationTitle);
+    for (MessageLine line : lines) {
+      if (!addPersonMessage(style, line)) {
+        style.addMessage(line.text, line.timestamp, line.sender);
+      }
+    }
+    return style;
+  }
+
+  private static Notification.InboxStyle inboxStyle(List<MessageLine> lines, Bundle extras) {
+    Notification.InboxStyle style = new Notification.InboxStyle();
+    CharSequence title = extras.getCharSequence(Notification.EXTRA_TITLE);
+    if (hasText(title)) style.setBigContentTitle(title);
+    style.setSummaryText(lines.size() + "件のメッセージ");
+    for (MessageLine line : lines) {
+      style.addLine(line.text);
+    }
+    return style;
+  }
+
+  private static synchronized void clearStack(String tag, int id) {
+    if (tag == null) {
+      List<NotificationKey> keys = new ArrayList<>();
+      for (NotificationKey key : stackedLines.keySet()) {
+        if (key.id == id) keys.add(key);
+      }
+      for (NotificationKey key : keys) {
+        stackedLines.remove(key);
+      }
+      return;
+    }
+    if (isLineMessageNotificationTag(LineVersion.get().notification, tag)) {
+      stackedLines.remove(new NotificationKey(tag, id));
+    }
+  }
+
+  private static synchronized void clearAllStacks() {
+    stackedLines.clear();
+  }
+
+  private static Notification findActiveNotification(Context context, NotificationKey key) {
+    try {
+      NotificationManager nm =
+          (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+      if (nm == null) return null;
+      for (StatusBarNotification sbn : nm.getActiveNotifications()) {
+        if (sbn.getId() == key.id && sameTag(sbn.getTag(), key.tag)) {
+          return sbn.getNotification();
+        }
+      }
+    } catch (Throwable ignored) {
+    }
+    return null;
+  }
+
+  private static void addLine(List<MessageLine> lines, MessageLine next) {
+    if (next == null || !hasText(next.text)) return;
+    for (int i = 0; i < lines.size(); i++) {
+      MessageLine current = lines.get(i);
+      if (hasText(next.messageId) && next.messageId.equals(current.messageId)) {
+        lines.set(i, next);
+        return;
+      }
+      if (!hasText(next.messageId)
+          && sameText(next.text, current.text)
+          && sameText(next.sender, current.sender)) {
+        return;
+      }
+    }
+    lines.add(next);
+  }
+
+  private static MessageLine incomingLine(Bundle extras, String messageId, CharSequence text) {
+    MessageLine messagingLine = latestMessagingLine(extras, messageId);
+    if (messagingLine != null) return messagingLine;
+    return new MessageLine(
+        messageId, messageLineText(extras, text), null, null, null, System.currentTimeMillis());
+  }
+
+  private static void addMessagingLines(List<MessageLine> lines, Bundle extras) {
+    Parcelable[] messages = extras.getParcelableArray(Notification.EXTRA_MESSAGES);
+    if (messages == null) return;
+
+    CharSequence conversationTitle = conversationTitle(extras);
+    for (Parcelable message : messages) {
+      if (message instanceof Bundle) {
+        MessageLine line = messagingLine((Bundle) message, null, conversationTitle);
+        if (line != null) addLine(lines, line);
+      }
+    }
+  }
+
+  private static MessageLine latestMessagingLine(Bundle extras, String messageId) {
+    Parcelable[] messages = extras.getParcelableArray(Notification.EXTRA_MESSAGES);
+    if (messages == null) return null;
+
+    CharSequence conversationTitle = conversationTitle(extras);
+    for (int i = messages.length - 1; i >= 0; i--) {
+      if (messages[i] instanceof Bundle) {
+        MessageLine line = messagingLine((Bundle) messages[i], messageId, conversationTitle);
+        if (line != null) return line;
+      }
+    }
+    return null;
+  }
+
+  private static MessageLine messagingLine(
+      Bundle message, String messageId, CharSequence conversationTitle) {
+    CharSequence text = message.getCharSequence(MESSAGE_TEXT_KEY);
+    if (!hasText(text)) return null;
+
+    Parcelable senderPerson = message.getParcelable(MESSAGE_SENDER_PERSON_KEY);
+    CharSequence sender = messageSender(message, senderPerson);
+    long timestamp = message.getLong(MESSAGE_TIME_KEY, System.currentTimeMillis());
+    return new MessageLine(messageId, text, sender, senderPerson, conversationTitle, timestamp);
+  }
+
+  private static boolean addPersonMessage(Notification.MessagingStyle style, MessageLine line) {
+    if (line.senderPerson == null) return false;
+    try {
+      Class<?> personClass = Class.forName("android.app.Person");
+      if (!personClass.isInstance(line.senderPerson)) return false;
+      style
+          .getClass()
+          .getMethod("addMessage", CharSequence.class, long.class, personClass)
+          .invoke(style, line.text, line.timestamp, line.senderPerson);
+      return true;
+    } catch (Throwable ignored) {
+      return false;
+    }
+  }
+
+  private static CharSequence messageSender(Bundle message, Parcelable senderPerson) {
+    CharSequence sender = message.getCharSequence(MESSAGE_SENDER_KEY);
+    if (hasText(sender)) return sender;
+    if (senderPerson == null) return null;
+    try {
+      Object name = senderPerson.getClass().getMethod("getName").invoke(senderPerson);
+      if (name instanceof CharSequence) return (CharSequence) name;
+    } catch (Throwable ignored) {
+    }
+    return null;
+  }
+
+  private static CharSequence firstText(Bundle extras) {
+    if (extras == null) return null;
+    CharSequence text = extras.getCharSequence(Notification.EXTRA_TEXT);
+    if (hasText(text)) return text;
+    return extras.getCharSequence(Notification.EXTRA_BIG_TEXT);
+  }
+
+  private static CharSequence messageLineText(Bundle extras, CharSequence text) {
+    if (extras == null) return text;
+
+    CharSequence title = extras.getCharSequence(Notification.EXTRA_TITLE);
+    CharSequence subText = extras.getCharSequence(Notification.EXTRA_SUB_TEXT);
+    if (!hasText(title) || !hasText(subText)) return text;
+    if (sameText(title, subText)) return text;
+    if (startsWithSenderPrefix(text, title)) return text;
+
+    return title + ": " + text;
+  }
+
+  private static CharSequence conversationTitle(List<MessageLine> lines, Bundle extras) {
+    for (int i = lines.size() - 1; i >= 0; i--) {
+      CharSequence title = lines.get(i).conversationTitle;
+      if (hasText(title)) return title;
+    }
+    return conversationTitle(extras);
+  }
+
+  private static CharSequence conversationTitle(Bundle extras) {
+    if (extras == null) return null;
+    CharSequence conversationTitle = extras.getCharSequence(Notification.EXTRA_CONVERSATION_TITLE);
+    if (hasText(conversationTitle)) return conversationTitle;
+
+    CharSequence title = extras.getCharSequence(Notification.EXTRA_TITLE);
+    CharSequence subText = extras.getCharSequence(Notification.EXTRA_SUB_TEXT);
+    if (hasText(title) && hasText(subText) && !sameText(title, subText)) return subText;
+    return null;
+  }
+
+  private static boolean usesMessagingStyle(List<MessageLine> lines) {
+    for (MessageLine line : lines) {
+      if (hasText(line.sender) || line.senderPerson != null) return true;
+    }
+    return false;
+  }
+
+  private static String stringExtra(Bundle extras, String key) {
+    if (extras == null) return null;
+    Object value = extras.get(key);
+    return value == null ? null : value.toString();
+  }
+
+  private static boolean hasText(CharSequence text) {
+    return text != null && text.length() > 0;
+  }
+
+  private static boolean sameTag(String a, String b) {
+    return a == null ? b == null : a.equals(b);
+  }
+
+  private static boolean sameText(CharSequence a, CharSequence b) {
+    return a == null ? b == null : b != null && a.toString().contentEquals(b);
+  }
+
+  private static boolean startsWithSenderPrefix(CharSequence text, CharSequence sender) {
+    if (!hasText(text) || !hasText(sender)) return false;
+    return text.toString().startsWith(sender + ": ") || text.toString().startsWith(sender + " : ");
+  }
+
+  private static boolean isLineMessageNotificationTag(
+      LineVersion.Config.Notification notificationConfig, String tag) {
+    return sameNonEmptyText(tag, notificationConfig.messageNotificationTag)
+        || sameNonEmptyText(tag, notificationConfig.chatNotificationTag);
+  }
+
+  private static boolean sameNonEmptyText(String a, String b) {
+    return hasText(a) && a.equals(b);
+  }
+
+  private static final class NotificationKey {
+    final String tag;
+    final int id;
+
+    NotificationKey(String tag, int id) {
+      this.tag = tag;
+      this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (!(obj instanceof NotificationKey)) return false;
+      NotificationKey other = (NotificationKey) obj;
+      return id == other.id && sameTag(tag, other.tag);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * id + (tag == null ? 0 : tag.hashCode());
+    }
+  }
+
+  private static final class MessageLine {
+    final String messageId;
+    final CharSequence text;
+    final CharSequence sender;
+    final Parcelable senderPerson;
+    final CharSequence conversationTitle;
+    final long timestamp;
+
+    MessageLine(
+        String messageId,
+        CharSequence text,
+        CharSequence sender,
+        Parcelable senderPerson,
+        CharSequence conversationTitle,
+        long timestamp) {
+      this.messageId = messageId;
+      this.text = text;
+      this.sender = sender;
+      this.senderPerson = senderPerson;
+      this.conversationTitle = conversationTitle;
+      this.timestamp = timestamp;
+    }
+  }
+}

--- a/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
+++ b/app/src/main/java/app/zipper/knot/utils/ModuleStrings.java
@@ -180,6 +180,10 @@ public class ModuleStrings {
   public static final String OPT_REACTION_NOTIFICATION_DESC =
       "メッセージについたリアクションを通知します。※アプリを開くと送信されます。フォアグラウンドサービス化している場合、LINEを起動していなくても通知が届きます。";
 
+  public static final String OPT_STACK_MESSAGE_NOTIFICATIONS_LABEL = "通知を上書きしない";
+  public static final String OPT_STACK_MESSAGE_NOTIFICATIONS_DESC =
+      "通知を上書きせず、最大7件まで一つの通知の中にまとめて表示します。";
+
   public static final String OPT_REMOVE_NOTIFICATION_MUTE_BUTTON_LABEL = "「通知をオフ」ボタンを非表示";
   public static final String OPT_REMOVE_NOTIFICATION_MUTE_BUTTON_DESC =
       "LINEの通知に表示される「通知をオフ」ボタンを削除します。";


### PR DESCRIPTION
## 概要
<!-- このPRの目的・変更内容を簡潔に記載してください -->
Android版LINEではiOS版と異なり、通知が来るたびに上書きされ、最後の一件しか見れないため、InstagramやDiscordのように通知が来るたびに通知に追加していく仕組みを追加しました

## 変更種別
<!-- 該当する項目にチェックを入れてください -->
- [x] 新機能
- [ ] 不具合修正
- [ ] リファクタリング
- [ ] パフォーマンス改善
- [ ] ドキュメント更新
- [ ] その他（記載してください）

## 影響範囲
<!-- このPRが影響する機能や領域をチェックしてください -->
- [ ] 既読回避 / 既読履歴
- [ ] 送信取り消し防止
- [ ] 広告・おすすめ非表示
- [ ] タブカスタマイズ
- [ ] カスタムフォント
- [ ] 写真・動画送信
- [ ] URL / ブラウザ
- [x] 通知 (FCM Fix含む)
- [x] UI改善
- [ ] その他（記載してください）

## 関連Issue
<!-- 関連するIssue番号があれば記載してください -->
なし

## 変更内容
<!-- 具体的な変更点をリスト形式で記載してください -->
 - LINEのメッセージ通知が新着ごとに上書きされず、同一トーク内の通知本文を最大7件までスタック表示するようにしました
  - 個人トークでは同一トークの連続通知をまとめて表示します
  - グループチャットではLINE通知内の `MessagingStyle` / `Person` 情報を優先して利用し、送信者名や送信者アイコンを表示します
  - LINEの通知tag / message id extraをLineVersion側に定義しました
 
## 動作確認
<!-- 実施した動作確認の内容をチェックしてください -->
- [x] ビルドが成功すること
- [x] Root環境 (LSPosed/Vector) で動作確認
- [x] 非Root環境 (NPatch) で動作確認
- [x] 既存機能にデグレードがないこと

## テストしたLINEバージョン
<!-- 動作確認したLINEのバージョンにチェックを入れてください -->
- [ ] 26.8.0
- [x] 26.9.0
- [ ] 26.10.0
- [ ] その他（記載してください）

### 確認手順
<!-- レビュアーが確認するための手順を記載してください -->
1. 設定画面で「メッセージ通知をスタック」を有効にする
  2. 同一の個人トークで複数回メッセージを受信し、通知が1件に上書きされず複数行で表示されることを確認する
  3. 同一のグループトークで複数メンバーからメッセージを受信し、通知内で送信者名、アイコン付きで表示されることを確認する
  4. 通知をタップまたは消去したあと、次回通知で古いスタックが残らないことを確認する
  5. 返信機能が正常に動作していることを確認する


## レビュー重点項目
<!-- レビュアーに特に確認してほしいポイントがあれば記載してください -->


## 画面キャプチャ
<!-- UI変更がある場合は、before/afterのスクリーンショットを添付してください --> 
<img width="1079" height="488" alt="Screenshot_2026-07-04-00-24-29-09_b783bf344239542886fee7b48fa4b892" src="https://github.com/user-attachments/assets/3aebf7fc-664c-4600-8f14-a47ccb808af6" />

## 補足事項
<!-- その他、共有事項があれば記載してください -->
コードは読んでいますが、大部分をcodexで作成したため、一部のコードは冗長な可能性があります
 LINE通知内に `MessagingStyle` / `Person` 情報が含まれる場合は、それを優先して会話通知として再構築します。取得できない通知では `InboxStyle` にフォールバックするため、送信者名が本文側に付与される表示になります
  通知が長くなりすぎるのを避けるため、スタック表示は最大7件に制限しています