### PR TITLE
ダークテーマ判定とAMOLED表示の不具合を修正

### DIFF
--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -71,6 +71,7 @@ public class LineVersion {
       public String nightModeConfiguratorClass = "";
       public String methodApplyNightMode = "";
       public String fieldSystemDarkMode = "";
+      public String inputPassActivityClass = "";
       public String darkThemeManagerClass = "";
       public String methodIsDarkTheme = "";
       public String methodThemeMode = "";

--- a/app/src/main/java/app/zipper/knot/LineVersion.java
+++ b/app/src/main/java/app/zipper/knot/LineVersion.java
@@ -71,6 +71,9 @@ public class LineVersion {
       public String nightModeConfiguratorClass = "";
       public String methodApplyNightMode = "";
       public String fieldSystemDarkMode = "";
+      public String darkThemeManagerClass = "";
+      public String methodIsDarkTheme = "";
+      public String methodThemeMode = "";
     }
 
     public static class HomeTab {

--- a/app/src/main/java/app/zipper/knot/hooks/AmoledThemeHook.java
+++ b/app/src/main/java/app/zipper/knot/hooks/AmoledThemeHook.java
@@ -99,6 +99,7 @@ public class AmoledThemeHook implements BaseHook {
             + themeBundleBytes.length);
 
     installFileRedirects();
+    installBottomNavigationFileBridge();
     installThriftValidationHijack(lpparam);
     installNavigationBarBlackening();
     NightModePin.install(lpparam, () -> Main.options.useAmoledTheme.enabled, "Knot: AmoledTheme");
@@ -260,6 +261,47 @@ public class AmoledThemeHook implements BaseHook {
     }
     for (Executable m : decodeFileMethods()) {
       Knot.module.hook(m).intercept(openHook);
+    }
+  }
+
+  private void installBottomNavigationFileBridge() {
+    try {
+      Knot.module
+          .hook(Reflect.findMethodExact(File.class, "exists"))
+          .intercept(
+              chain -> {
+                Object original = chain.proceed();
+                if (Boolean.TRUE.equals(original) || !Main.options.useAmoledTheme.enabled) {
+                  return original;
+                }
+
+                File requested = (File) chain.getThisObject();
+                String name = requested.getName();
+                if (name == null
+                    || !name.startsWith("gnb_bottom_ic_")
+                    || !name.endsWith(".png")) {
+                  return original;
+                }
+
+                String path = requested.getAbsolutePath();
+                if (path == null || !looksLikeThemePath(path)) return original;
+
+                Context ctx = SettingsStore.getContext();
+                if (ctx == null) return original;
+                File cached =
+                    new File(new File(new File(ctx.getCacheDir(), CACHE_SUBDIR), "images"), name);
+                if (cached.length() <= 0L) return original;
+
+                Knot.log(
+                    "Knot: AmoledTheme: BottomNav File.exists "
+                        + requested
+                        + " -> "
+                        + cached);
+                return Boolean.TRUE;
+              });
+      Knot.log("Knot: AmoledTheme: BottomNav File.exists bridge installed");
+    } catch (Throwable t) {
+      Knot.log("Knot: AmoledTheme: BottomNav File.exists bridge unavailable: " + t);
     }
   }
 

--- a/app/src/main/java/app/zipper/knot/hooks/AmoledThemeHook.java
+++ b/app/src/main/java/app/zipper/knot/hooks/AmoledThemeHook.java
@@ -1,11 +1,15 @@
 package app.zipper.knot.hooks;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.os.Build;
+import android.view.View;
+import android.view.Window;
 import app.zipper.knot.Knot;
 import app.zipper.knot.KnotConfig;
 import app.zipper.knot.LineVersion;
@@ -49,6 +53,11 @@ public class AmoledThemeHook implements BaseHook {
   private static final String SEMANTIC_SECTION = "theme.semantic";
   private static final String SEMANTIC_SUFFIX = ".background.color";
   private static final int[] NO_COLOR = new int[0];
+
+  private static final String PRIMARY_BACKGROUND = "primaryBackground";
+  private static final String[] PASSCODE_BACKGROUND_VIEWS = {
+    "passcode_bg", "passcode_top", "passcode_fake_status_bar"
+  };
 
   private static final Set<String> SEMANTIC_SKIP_TOKENS =
       Collections.unmodifiableSet(new HashSet<>(Arrays.asList("primaryFill")));
@@ -102,8 +111,17 @@ public class AmoledThemeHook implements BaseHook {
     installBottomNavigationFileBridge();
     installThriftValidationHijack(lpparam);
     installNavigationBarBlackening();
-    NightModePin.install(lpparam, () -> Main.options.useAmoledTheme.enabled, "Knot: AmoledTheme");
+    installNightModePin(lpparam);
     installThemeSemanticColors();
+    installPasscodeBackgroundOverride(lpparam);
+  }
+
+  private void installNightModePin(LoadParam lpparam) {
+    try {
+      NightModePin.install(lpparam, () -> Main.options.useAmoledTheme.enabled, "Knot: AmoledTheme");
+    } catch (Throwable t) {
+      Knot.log("Knot: AmoledTheme: night mode pin failed: " + t);
+    }
   }
 
   private void installThemeSemanticColors() {
@@ -162,19 +180,61 @@ public class AmoledThemeHook implements BaseHook {
     return color;
   }
 
+  private void installPasscodeBackgroundOverride(LoadParam lpparam) {
+    LineVersion.Config cfg = LineVersion.get();
+    if (cfg == null || cfg.nightMode.inputPassActivityClass.isEmpty()) return;
+
+    try {
+      Class<?> inputPassActivity =
+          Reflect.findClass(cfg.nightMode.inputPassActivityClass, lpparam.classLoader);
+      Knot.module
+          .hook(Reflect.findMethodExact(inputPassActivity, "onStart"))
+          .intercept(
+              chain -> {
+                Object result = chain.proceed();
+                if (Main.options.useAmoledTheme.enabled) {
+                  applyPasscodeBackground((Activity) chain.getThisObject());
+                }
+                return result;
+              });
+    } catch (Throwable t) {
+      Knot.log("Knot: AmoledTheme: passcode background unavailable: " + t);
+    }
+  }
+
+  private static void applyPasscodeBackground(Activity activity) {
+    try {
+      Resources res = activity.getResources();
+      String pkg = activity.getPackageName();
+      int primaryBackgroundId = res.getIdentifier(PRIMARY_BACKGROUND, "color", pkg);
+      if (primaryBackgroundId == 0) return;
+
+      Integer color = resolve(res, primaryBackgroundId);
+      if (color == null) return;
+
+      for (String name : PASSCODE_BACKGROUND_VIEWS) {
+        int id = res.getIdentifier(name, "id", pkg);
+        if (id == 0) continue;
+        View view = activity.findViewById(id);
+        if (view != null) view.setBackgroundColor(color);
+      }
+    } catch (Throwable t) {
+      Knot.log("Knot: AmoledTheme: passcode background failed: " + t);
+    }
+  }
+
   private void installNavigationBarBlackening() {
     try {
       Knot.module
-          .hook(Reflect.findMethodExact(android.app.Activity.class, "onResume"))
+          .hook(Reflect.findMethodExact(Activity.class, "onResume"))
           .intercept(
               chain -> {
                 Object result = chain.proceed();
                 try {
-                  android.view.Window w =
-                      ((android.app.Activity) chain.getThisObject()).getWindow();
+                  Window w = ((Activity) chain.getThisObject()).getWindow();
                   if (w != null && !w.isFloating()) {
                     w.getDecorView().setBackgroundColor(0xFF000000);
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                       w.setNavigationBarContrastEnforced(false);
                     }
                   }
@@ -277,9 +337,7 @@ public class AmoledThemeHook implements BaseHook {
 
                 File requested = (File) chain.getThisObject();
                 String name = requested.getName();
-                if (name == null
-                    || !name.startsWith("gnb_bottom_ic_")
-                    || !name.endsWith(".png")) {
+                if (name == null || !name.startsWith("gnb_bottom_ic_") || !name.endsWith(".png")) {
                   return original;
                 }
 
@@ -292,11 +350,7 @@ public class AmoledThemeHook implements BaseHook {
                     new File(new File(new File(ctx.getCacheDir(), CACHE_SUBDIR), "images"), name);
                 if (cached.length() <= 0L) return original;
 
-                Knot.log(
-                    "Knot: AmoledTheme: BottomNav File.exists "
-                        + requested
-                        + " -> "
-                        + cached);
+                Knot.log("Knot: AmoledTheme: BottomNav File.exists " + requested + " -> " + cached);
                 return Boolean.TRUE;
               });
       Knot.log("Knot: AmoledTheme: BottomNav File.exists bridge installed");

--- a/app/src/main/java/app/zipper/knot/hooks/NightModePin.java
+++ b/app/src/main/java/app/zipper/knot/hooks/NightModePin.java
@@ -5,6 +5,7 @@ import app.zipper.knot.LineVersion;
 import app.zipper.knot.LoadParam;
 import app.zipper.knot.Reflect;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.function.BooleanSupplier;
 
 final class NightModePin {
@@ -13,8 +14,11 @@ final class NightModePin {
 
   static void install(LoadParam lpparam, BooleanSupplier active, String tag) {
     LineVersion.Config cfg = LineVersion.get();
-    if (cfg == null
-        || cfg.nightMode.nightModeConfiguratorClass.isEmpty()
+    if (cfg == null) return;
+
+    installDarkThemePredicates(cfg, lpparam, active, tag);
+
+    if (cfg.nightMode.nightModeConfiguratorClass.isEmpty()
         || cfg.nightMode.methodApplyNightMode.isEmpty()) {
       return;
     }
@@ -48,6 +52,65 @@ final class NightModePin {
             + "."
             + cfg.nightMode.methodApplyNightMode
             + (systemDarkMode == null ? " (only while the OS is in dark mode)" : ""));
+  }
+
+  private static void installDarkThemePredicates(
+      LineVersion.Config cfg, LoadParam lpparam, BooleanSupplier active, String tag) {
+    String className = cfg.nightMode.darkThemeManagerClass;
+    if (className.isEmpty()) return;
+
+    Class<?> themeManager;
+    try {
+      themeManager = Reflect.findClass(className, lpparam.classLoader);
+    } catch (Throwable t) {
+      Knot.log(tag + ": dark theme manager " + className + " not found: " + t);
+      return;
+    }
+
+    if (!cfg.nightMode.methodIsDarkTheme.isEmpty()) {
+      try {
+        Method method = Reflect.findMethodExact(themeManager, cfg.nightMode.methodIsDarkTheme);
+        if (method.getReturnType() == boolean.class) {
+          Knot.module
+              .hook(method)
+              .intercept(
+                  chain -> {
+                    if (active.getAsBoolean()) return Boolean.TRUE;
+                    return chain.proceed();
+                  });
+        }
+      } catch (Throwable t) {
+        Knot.log(tag + ": dark theme predicate unavailable on " + className + ": " + t);
+      }
+    }
+
+    if (!cfg.nightMode.methodThemeMode.isEmpty()) {
+      try {
+        Method method = Reflect.findMethodExact(themeManager, cfg.nightMode.methodThemeMode);
+        Object darkMode = enumConstant(method.getReturnType(), "DARK");
+        if (darkMode != null) {
+          Knot.module
+              .hook(method)
+              .intercept(
+                  chain -> {
+                    if (active.getAsBoolean()) return darkMode;
+                    return chain.proceed();
+                  });
+        }
+      } catch (Throwable t) {
+        Knot.log(tag + ": theme mode predicate unavailable on " + className + ": " + t);
+      }
+    }
+  }
+
+  private static Object enumConstant(Class<?> type, String name) {
+    if (type == null || !type.isEnum()) return null;
+    Object[] constants = type.getEnumConstants();
+    if (constants == null) return null;
+    for (Object constant : constants) {
+      if (constant instanceof Enum && name.equals(((Enum<?>) constant).name())) return constant;
+    }
+    return null;
   }
 
   private static Field booleanField(Class<?> owner, String name, String tag) {

--- a/app/src/main/java/app/zipper/knot/versions/Version26101.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version26101.java
@@ -375,7 +375,6 @@ public class Version26101 {
     v.chatEditSelectAll.methodToggleItem = "m";
     v.chatEditSelectAll.methodIsItemSelected = "k";
 
-
     v.messageEditHistory.editRequestClass = "sz7.h";
     v.messageEditHistory.editRequestIdField = "b";
     v.messageEditHistory.editRequestTextField = "d";
@@ -404,6 +403,7 @@ public class Version26101 {
     v.nightMode.nightModeConfiguratorClass = "z00.a";
     v.nightMode.methodApplyNightMode = "a";
     v.nightMode.fieldSystemDarkMode = "a";
+    v.nightMode.inputPassActivityClass = "com.linecorp.line.passlock.InputPassActivity";
     v.nightMode.darkThemeManagerClass = "oy5.j";
     v.nightMode.methodIsDarkTheme = "n";
     v.nightMode.methodThemeMode = "B";

--- a/app/src/main/java/app/zipper/knot/versions/Version26101.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version26101.java
@@ -404,6 +404,9 @@ public class Version26101 {
     v.nightMode.nightModeConfiguratorClass = "z00.a";
     v.nightMode.methodApplyNightMode = "a";
     v.nightMode.fieldSystemDarkMode = "a";
+    v.nightMode.darkThemeManagerClass = "oy5.j";
+    v.nightMode.methodIsDarkTheme = "n";
+    v.nightMode.methodThemeMode = "B";
 
     return v;
   }

--- a/app/src/main/java/app/zipper/knot/versions/Version26110.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version26110.java
@@ -375,7 +375,6 @@ public class Version26110 {
     v.chatEditSelectAll.methodToggleItem = "h";
     v.chatEditSelectAll.methodIsItemSelected = "k";
 
-
     v.messageEditHistory.editRequestClass = "i38.h";
     v.messageEditHistory.editRequestIdField = "b";
     v.messageEditHistory.editRequestTextField = "d";
@@ -404,6 +403,7 @@ public class Version26110 {
     v.nightMode.nightModeConfiguratorClass = "z00.a";
     v.nightMode.methodApplyNightMode = "a";
     v.nightMode.fieldSystemDarkMode = "a";
+    v.nightMode.inputPassActivityClass = "com.linecorp.line.passlock.InputPassActivity";
     v.nightMode.darkThemeManagerClass = "o16.j";
     v.nightMode.methodIsDarkTheme = "n";
     v.nightMode.methodThemeMode = "z";

--- a/app/src/main/java/app/zipper/knot/versions/Version26110.java
+++ b/app/src/main/java/app/zipper/knot/versions/Version26110.java
@@ -404,6 +404,9 @@ public class Version26110 {
     v.nightMode.nightModeConfiguratorClass = "z00.a";
     v.nightMode.methodApplyNightMode = "a";
     v.nightMode.fieldSystemDarkMode = "a";
+    v.nightMode.darkThemeManagerClass = "o16.j";
+    v.nightMode.methodIsDarkTheme = "n";
+    v.nightMode.methodThemeMode = "z";
 
     return v;
   }


### PR DESCRIPTION
## 概要
<!-- このPRの目的・変更内容を簡潔に記載してください -->
AMOLEDテーマ使用時やダークモードUIを維持時に、LINEの一部UIがダークテーマとして正しく判定されず、テーマ画像や背景色が適切に適用されない問題を修正します。

主にダークテーマ判定、下部ナビゲーション画像の存在判定、PIN入力画面の背景色を補完します。

## 変更種別
<!-- 該当する項目にチェックを入れてください -->
- [ ] 新機能
- [x] 不具合修正
- [ ] リファクタリング
- [ ] パフォーマンス改善
- [ ] ドキュメント更新
- [ ] その他（記載してください）

## 影響範囲
<!-- このPRが影響する機能や領域をチェックしてください -->
- [ ] 既読回避 / 既読履歴
- [ ] 送信取り消し防止
- [ ] 広告・おすすめ非表示
- [ ] タブカスタマイズ
- [ ] カスタムフォント
- [ ] 写真・動画送信
- [ ] URL / ブラウザ
- [ ] 通知 (FCM Fix含む)
- [x] UI改善
- [ ] その他（記載してください）

## 関連Issue
<!-- 関連するIssue番号があれば記載してください -->


## 変更内容
<!-- 具体的な変更点をリスト形式で記載してください -->
- AMOLEDテーマ使用時や「ダークモードUIを維持」有効時に、LINEの一部UIがダークテーマとして正しく判定されず、テーマ画像や背景色が適切に適用されない問題を修正
- AMOLEDテーマの下部ナビゲーション画像について、画像ファイルの存在判定を正しく行えるように修正
- PIN入力画面の背景色をAMOLEDテーマに合わせて変更

## 動作確認
<!-- 実施した動作確認の内容をチェックしてください -->
- [x] ビルドが成功すること
- [x] Root環境 (LSPosed/Vector) で動作確認
- [ ] 非Root環境 (NPatch) で動作確認
- [x] 既存機能にデグレードがないこと

## テストしたLINEバージョン
<!-- 動作確認したLINEのバージョンにチェックを入れてください -->
- [ ] 26.8.0
- [ ] 26.9.0
- [ ] 26.10.0
- [ ] 26.10.1
- [x] 26.11.0
- [ ] その他（記載してください）

### 確認手順
<!-- レビュアーが確認するための手順を記載してください -->
1. Knotで「AMOLEDテーマ」または「ダークモードUIを維持」を有効にしてLINEを再起動する
2. ホーム画面の下部ナビゲーションを確認し、AMOLEDテーマ用の画像が正常に適用されていることを確認する
3. LINEのPINコードロックを有効にしてPIN入力画面を表示し、画面上部を含む背景がAMOLEDテーマの背景色で表示されることを確認する

## レビュー重点項目
<!-- レビュアーに特に確認してほしいポイントがあれば記載してください -->
- ダークテーマ判定の補完が既存のテーマ切り替え処理へ影響しないこと
- PIN入力画面の背景色補完が対応していないLINEバージョンでは安全にスキップされること

## 画面キャプチャ
<!-- UI変更がある場合は、before/afterのスクリーンショットを添付してください -->

| 画面 | Before | After |
|------|--------|-------|
| PIN入力画面 | <img width="360" src="https://github.com/user-attachments/assets/f6d19f91-e595-4fd4-89ee-915c8c1dd9d4" /> | <img width="360" src="https://github.com/user-attachments/assets/6c43cd46-8f1f-42ce-9941-45a95c1a700d" /> |
| 設定画面 | <img width="360" src="https://github.com/user-attachments/assets/6fd866e1-8eb6-444d-9b09-c17ff3e558e0" /> | <img width="360" src="https://github.com/user-attachments/assets/2f2cfa1f-fc7a-4d84-94e5-977d73037dfa" /> |
| Mini | <img width="360" src="https://github.com/user-attachments/assets/60d8f198-b3e0-4c95-a669-10e697938e35" /> | <img width="360" src="https://github.com/user-attachments/assets/d659692e-a252-4998-8d24-a89aa70f5fe9" /> |

## 補足事項
<!-- その他、共有事項があれば記載してください -->
- 26.10.1はapkの解析のみ行い、該当バージョンでは実機テストを行っていません